### PR TITLE
Updated EventType enum usages to non-obsolete api

### DIFF
--- a/Editor/ReorderableArrayInspector.cs
+++ b/Editor/ReorderableArrayInspector.cs
@@ -182,7 +182,7 @@ namespace SubjectNerd.Utilities
 				if (evt == null)
 					return true;
 
-				if (evt.type == EventType.dragUpdated || evt.type == EventType.dragPerform)
+				if (evt.type == EventType.DragUpdated || evt.type == EventType.DragPerform)
 				{
 					if (dropRect.Contains(evt.mousePosition) == false)
 						return true;


### PR DESCRIPTION
Just pulled this in to Unity 2018.2 and apparently EventType.dragUpdated is now EventType.DragUpdated and EventType.dragPerform is now EventType.DragPerform. So I made those simple changes. Cheers!