### PR TITLE
Avoid Stomping EditorApplication.delayCall Delegate

### DIFF
--- a/Editor/ReorderableArrayInspector.cs
+++ b/Editor/ReorderableArrayInspector.cs
@@ -62,7 +62,7 @@ namespace SubjectNerd.Utilities
 		{
 			FORCE_INIT = true;
 
-			EditorApplication.delayCall = () => { EditorApplication.delayCall = () => { FORCE_INIT = false; }; };
+			EditorApplication.delayCall += () => { EditorApplication.delayCall += () => { FORCE_INIT = false; }; };
 		}
 
 		private static GUIStyle styleHighlight;


### PR DESCRIPTION
This delegate should be subscribed to, with `+=`, instead of completely reset with an equality operator.  It seems fine in earlier versions of Unity, but this is causing very, very weird editor problems and crashes with Unity 2019.3 betas.